### PR TITLE
Add support for generating generic QR code

### DIFF
--- a/authy/api/resources.py
+++ b/authy/api/resources.py
@@ -259,6 +259,18 @@ class Users(Resource):
         resp = self.post("/protected/json/users/{0}/delete".format(user_id))
 
         return User(self, resp)
+    
+    def generate_qr(self, user_id, size=None, label=None):
+        data = {}
+
+        if size is not None:
+            data['qr_size'] = size
+        if label is not None:
+            data['label'] = label
+
+        resp = self.post("/protected/json/users/{}/secret".format(user_id), data)
+
+        return User(self, resp)
 
 
 class Token(Instance):


### PR DESCRIPTION
Adds support for QR code generation https://www.twilio.com/docs/authy/api/one-time-passwords?code-sample=code-create-a-generic-authenticator-app-qr-code-7

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
