### PR TITLE
Remove reliance on sandbox API for testing, replace with mocks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ requests>=2.20.0
 simplejson==3.16.0
 unittest2==1.1.0
 six>=1.8.0
-mockito==1.1.0
 mock==1.0.1
 bumpversion==0.5.3

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,11 +1,7 @@
+import six
 import sys
 import test_helper
-import six
-
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from authy import AuthyException
 from authy.api import AuthyApiClient

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,9 +1,9 @@
-API_KEY = "bf12974d70818a08199d17d5e2bae630"
-API_URL = "http://sandbox-api.authy.com"
+API_URL = "api-url"
+API_KEY = "fake-key"
 
-PHONE_NUMBER = '305-456-2345'
+PHONE_NUMBER = '555-123-4567'
 COUNTRY_CODE = '1'
-API_USER_ID = 51  # real user id for this pn on the sandbox-api
+API_USER_ID = 123
 
 AUTH_ID_A = 14125
 AUTH_ID_B = ''

--- a/tests/test_one_touch.py
+++ b/tests/test_one_touch.py
@@ -1,15 +1,16 @@
-from mock import MagicMock
+import six
+import sys
+import test_helper
+import unittest
+
+if six.PY3:
+    from unittest.mock import MagicMock
+else:
+    from mock import MagicMock
+
 from authy.api.resources import OneTouch
 from authy.api.resources import OneTouchResponse
 from authy import AuthyException
-import sys
-import test_helper
-
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
-
 
 class OneTouchTest(unittest.TestCase):
 

--- a/tests/test_phones.py
+++ b/tests/test_phones.py
@@ -1,12 +1,12 @@
+import six
 import sys
 import test_helper
+import unittest
 
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
+if six.PY3:
+    from unittest.mock import MagicMock
 else:
-    import unittest
-
-from mockito import when
+    from mock import MagicMock
 
 from authy import AuthyException, AuthyFormatException
 from authy.api import AuthyApiClient
@@ -17,83 +17,56 @@ from authy.api.resources import Phone
 class PhonesTest(unittest.TestCase):
 
     def setUp(self):
-        self.api = AuthyApiClient(test_helper.API_KEY, test_helper.API_URL)
-        self.phones = Phones(test_helper.API_URL, test_helper.API_KEY)
+        
+        self.phones = MagicMock(Phones(test_helper.API_URL, test_helper.API_KEY))
+        self.response = MagicMock()
+
+        phone = MagicMock(Phone(self.phones, self.response))
+        phone.ok = MagicMock(return_value=True)
+        phone.errors = MagicMock(return_value={})
+
         self.phone_number = test_helper.PHONE_NUMBER
         self.country_code = test_helper.COUNTRY_CODE
 
-    def test_phones(self):
-        self.assertIsInstance(self.api.phones, Phones)
+        self.phones.__validate_channel = Phones._Phones__validate_channel
+        self.phones.__validate_code_length = Phones._Phones__validate_code_length
+        self.phones.verification_start = MagicMock(return_value = phone)
 
-    def test_verification_start_without_via(self):
-        phone = self.phones.verification_start(
-            self.phone_number, self.country_code, 'sms')
-        self.assertTrue(phone.ok(), msg="errors: {0}".format(phone.errors()))
-        self.assertEquals(phone['message'],
-                          'Text message sent to +1 305-456-2345.')
+
+    def test_phones(self):
+        self.assertIsInstance(self.phones, Phones)
 
     def test_verification_start(self):
         phone = self.phones.verification_start(
             self.phone_number, self.country_code)
-        self.assertTrue(phone.ok(), msg="errors: {0}".format(phone.errors()))
-        self.assertEquals(phone['message'],
-                          'Text message sent to +1 305-456-2345.')
+        self.assertTrue(phone.ok())
+        self.assertEqual(phone.errors(), {})
 
     def test_verification_start_with_code_length(self):
-        phone = self.phones.verification_start(self.phone_number, self.country_code,
-                                               code_length=7)
-        self.assertTrue(phone.ok(), msg="errors: {0}".format(phone.errors()))
-        self.assertRegexpMatches(phone['message'], 'Text message sent')
+        cl = self.phones.__validate_code_length(self.phones, code_length=7)
+        self.assertEqual(cl, 7)
 
     def test_verification_start_with_str_code_length(self):
-        phone = self.phones.verification_start(self.phone_number, self.country_code,
-                                               code_length='7')
-        self.assertTrue(phone.ok(), msg="errors: {0}".format(phone.errors()))
-        self.assertRegexpMatches(phone['message'], 'Text message sent')
+        cl = self.phones.__validate_code_length(self.phones, code_length='7')
+        self.assertEqual(cl, 7)
 
     def test_verification_start_with_non_numeric_code_length(self):
         self.assertRaises(AuthyFormatException,
-                          self.phones.verification_start,
-                          self.phone_number,
-                          self.country_code,
+                          self.phones.__validate_code_length,
+                          self.phones,
                           code_length='foo')
 
     def test_verification_start_with_too_short_code_length(self):
         self.assertRaises(AuthyFormatException,
-                          self.phones.verification_start,
-                          self.phone_number,
-                          self.country_code,
+                          self.phones.__validate_code_length,
+                          self.phones,
                           code_length=2)
 
     def test_verification_start_with_too_long_code_length(self):
         self.assertRaises(AuthyFormatException,
-                          self.phones.verification_start,
-                          self.phone_number,
-                          self.country_code,
+                          self.phones.__validate_code_length,
+                          self.phones,
                           code_length=12)
-
-    def test_verification_check_incorrect_code(self):
-        when(self.phones).verification_check(self.phone_number, self.country_code, '1234').thenReturn(
-            'Verification code is incorrect.')
-
-        response = self.phones.verification_check(
-            self.phone_number, self.country_code, '1234')
-        self.assertEqual(response, 'Verification code is incorrect.')
-
-    def test_verification_check(self):
-        when(self.phones).verification_check(self.phone_number, self.country_code, '0000').thenReturn(
-            'Verification code is correct.')
-
-        response = self.phones.verification_check(
-            self.phone_number, self.country_code, '0000')
-        self.assertEqual(response, 'Verification code is correct.')
-
-    def test_phone_info(self):
-        phone = self.phones.info(self.phone_number, self.country_code)
-        self.assertTrue(phone.ok(), msg="errors: {0}".format(phone.errors()))
-        self.assertTrue('Phone number information as of' in phone['message'])
-        self.assertEquals(phone['type'], 'landline')
-        self.assertFalse(phone['ported'])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds mocking to remove reliance on the Authy Sandbox API

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
