### PR TITLE
Remove simplejson as a dependency for python 2.6+

### DIFF
--- a/authy/api/resources.py
+++ b/authy/api/resources.py
@@ -15,12 +15,9 @@ except ImportError:
     from urllib.parse import quote
 
 try:
-    import json
+    import json  # python 2.6+
 except ImportError:
-    try:
-        import simplejson as json
-    except ImportError:
-        from django.utils import simplejson as json
+    import simplejson as json  # python 2.5
 
 MIN_TOKEN_SIZE = 6
 MAX_TOKEN_SIZE = 12

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         "requests>=2.2.1",
         "six>=1.8.0",
         "simplejson>=3.4.0;python_version<'2.6'",
-    ]
+    ],
     packages=find_packages(),
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,11 @@ setup(
     author_email="dev-support@authy.com",
     url="http://github.com/authy/authy-python",
     keywords=["authy", "two factor", "authentication"],
-    install_requires=["requests>=2.2.1", "simplejson>=3.4.0", "six>=1.8.0"],
+    install_requires=[
+        "requests>=2.2.1",
+        "six>=1.8.0",
+        "simplejson>=3.4.0;python_version<'2.6'"
+    ]
     packages=find_packages(),
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     install_requires=[
         "requests>=2.2.1",
         "six>=1.8.0",
-        "simplejson>=3.4.0;python_version<'2.6'"
+        "simplejson>=3.4.0;python_version<'2.6'",
     ]
     packages=find_packages(),
     classifiers=[


### PR DESCRIPTION
Python 2.6 introduced the ``json`` module into the core language and so ``simplejson`` is only required in python versions prior to python 2.6. This fix ensures that pip will only install ``simplejson`` if the version of python being run is less than 2.6. This stops the un-needed installation of a library that won't ever actually get used by ``authy`` if a newer version of python is running.