### PR TITLE
Fix deprecation warnings due to invalid escape sequences.

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -22,7 +22,7 @@ class ApiClientTest(unittest.TestCase):
 
     def test_version(self):
         if six.PY3:
-            self.assertRegex(self.api.version(), '\d.\d*')
+            self.assertRegex(self.api.version(), r'\d.\d*')
         else:
             import re
             self.assertTrue(re.compile(r'\d.\d*').search(self.api.version()))


### PR DESCRIPTION
Fixes #50 . Fixes below deprecation warning due to invalid escape sequence by using raw string.

```
find . -iname '*.py' | xargs -P4 -I{} python3 -Wall -m py_compile {} 
./tests/test_client.py:25: DeprecationWarning: invalid escape sequence \d
  self.assertRegex(self.api.version(), '\d.\d*')
```

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
